### PR TITLE
Skip preflight check

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 EXTEND_ESLINT=true
+SKIP_PREFLIGHT_CHECK=true


### PR DESCRIPTION
# Description
Currently the following errors appear while compiling:
```
> pollen-wallet@0.5.3 build /home/galr/IdeaProjects/pollen-wallet
> craco build


There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.

The react-scripts package provided by Create React App requires a dependency:

  "babel-jest": "^24.9.0"

Don't try to install it manually: your package manager does it automatically.
However, a different version of babel-jest was detected higher up in the tree:

  /home/galr/node_modules/babel-jest (version: 26.6.3) 

Manually installing incompatible versions is known to cause hard-to-debug issues.

If you would prefer to ignore this check, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
That will permanently disable this message but you might encounter other issues.

To fix the dependency tree, try following the steps below in the exact order:

  1. Delete package-lock.json (not package.json!) and/or yarn.lock in your project folder.
  2. Delete node_modules in your project folder.
  3. Remove "babel-jest" from dependencies and/or devDependencies in the package.json file in your project folder.
  4. Run npm install or yarn, depending on the package manager you use.

In most cases, this should be enough to fix the problem.
If this has not helped, there are a few other things you can try:

  5. If you used npm, install yarn (http://yarnpkg.com/) and repeat the above steps with it instead.
     This may help because npm has known issues with package hoisting which may get resolved in future versions.

  6. Check if /home/galr/node_modules/babel-jest is outside your project directory.
     For example, you might have accidentally installed something in your home folder.

  7. Try running npm ls babel-jest in your project folder.
     This will tell you which other package (apart from the expected react-scripts) installed babel-jest.

If nothing else helps, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
That would permanently disable this preflight check in case you want to proceed anyway.

P.S. We know this message is long but please read the steps above :-) We hope you find them helpful!

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! pollen-wallet@0.5.3 build: `craco build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the pollen-wallet@0.5.3 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/galr/.npm/_logs/2021-05-10T14_28_55_512Z-debug.log
```

Since we don't use babel-jest directly, we can currently skip preflight checks and solve those problems.